### PR TITLE
Added helper for printing deprecated messages and fixed --no-git,dns options

### DIFF
--- a/bin/rhc-create-domain
+++ b/bin/rhc-create-domain
@@ -4,8 +4,7 @@ require 'rhc/coverage_helper'
 
 require 'rhc-common'
 
-puts "Warning: This command is deprecated and will be removed in the future. Please use 'rhc domain (create|update)' instead."
-puts""
+RHC::Helpers.deprecated_command('rhc domain (create|update)',true)
 
 #
 # print help

--- a/bin/rhc-ctl-domain
+++ b/bin/rhc-ctl-domain
@@ -4,8 +4,7 @@ require 'rhc/coverage_helper'
 
 require 'rhc-common'
 
-puts "Warning: This command is deprecated and will be removed in the future. Please use 'rhc sshkey' instead."
-puts""
+RHC::Helpers.deprecated_command('rhc sshkey',true)
 
 #
 # print help

--- a/bin/rhc-domain
+++ b/bin/rhc-domain
@@ -4,8 +4,7 @@ require 'rhc/coverage_helper'
 
 require 'rhc-common'
 
-puts "Warning: This command is deprecated and will be removed in the future. Please use 'rhc domain' instead."
-puts""
+RHC::Helpers.deprecated_command('rhc domain',true)
 
 #
 # print help

--- a/bin/rhc-domain-info
+++ b/bin/rhc-domain-info
@@ -4,8 +4,7 @@ require 'rhc/coverage_helper'
 
 require 'rhc-common'
 
-puts "Warning: This command is deprecated and will be removed in the future. Please use 'rhc domain show' instead."
-puts""
+RHC::Helpers.deprecated_command('rhc domain show',true)
 
 #
 # print help

--- a/bin/rhc-port-forward
+++ b/bin/rhc-port-forward
@@ -4,8 +4,7 @@ require 'rhc/coverage_helper'
 
 require 'rhc-common'
 
-puts "Warning: This command is deprecated and will be removed in the future. Please use 'rhc port-forward' instead."
-puts""
+RHC::Helpers.deprecated_command('rhc port-forward',true)
 
 #
 # print help

--- a/bin/rhc-sshkey
+++ b/bin/rhc-sshkey
@@ -4,8 +4,7 @@ require 'rhc/coverage_helper'
 
 require 'rhc-common'
 
-puts "Warning: This command is deprecated and will be removed in the future. Please use 'rhc sshkey' instead."
-puts""
+RHC::Helpers.deprecated_command('rhc sshkey',true)
 
 #
 # print help

--- a/bin/rhc-user-info
+++ b/bin/rhc-user-info
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
 # print deprecation warning
-
-puts "Warning: This command is deprecated. Please use rhc-domain-info instead."
-puts""
+RHC::Helpers.deprecated_command('rhc-domain-info',true)
 
 args = ""
 ARGV.each do|a|

--- a/lib/rhc/commands.rb
+++ b/lib/rhc/commands.rb
@@ -28,11 +28,7 @@ module RHC
       command = Commander::Runner.instance.active_command
 
       if deprecated[command_name]
-        msg = "The command 'rhc #{command_name}' is deprecated.  Please use 'rhc #{command.name}' instead."
-
-        raise DeprecatedError.new("#{msg} For porting and testing purposes you may switch this error to a warning by setting the DISABLE_DEPRECATED environment variable to 0.  It is not recommended to do so in a production environment as this command may be removed in future releases.") if RHC::Helpers.disable_deprecated?
-
-        warn "Warning: #{msg} For porting and testing purposes you may switch this warning to an error by setting the DISABLE_DEPRECATED environment variable to 1.  This command may be removed in future releases."
+        deprecated_cmd("rhc #{command.name}")
       end
     end
 

--- a/lib/rhc/commands/app.rb
+++ b/lib/rhc/commands/app.rb
@@ -16,13 +16,19 @@ module RHC::Commands
     option ["-g", "--gear-size size"], "The  size  of the gear for this app. Available gear sizes depend on the type of account you have."
     option ["-s", "--scaling"], "Enable scaling for this application"
     option ["-r", "--repo dir"], "Git Repo path (defaults to ./$app_name) (applicable to the  create command)"
-    option ["--no-git", "--nogit"], "Only  create  remote space, don't pull it locally"
-    option ["--no-dns", "--nodns"], "Skip DNS check. Must be used in combination with --nogit"
-    option ["--enable-jenkins [server_name]"], "Indicates to create a Jenkins application (if not already available)  and  embed the Jenkins client into this application. The default name will be 'jenkins' if not specified. Note that --nodns is ignored for the creation of the Jenkins application."
+    option ["--[no-]git"], "Only  create  remote space, don't pull it locally"
+    option ["--nogit"], "DEPRECATED! Only  create  remote space, don't pull it locally", :deprecated => {:arg => :git, :val => false}
+    option ["--[no-]dns"], "Skip DNS check. Must be used in combination with --no-git"
+    option ["--nodns"], "DEPRECATED! Skip DNS check. Must be used in combination with --no-git", :deprecated => {:arg => :dns, :val => false}
+    option ["--enable-jenkins [server_name]"], "Indicates to create a Jenkins application (if not already available)  and  embed the Jenkins client into this application. The default name will be 'jenkins' if not specified. Note that --no-dns is ignored for the creation of the Jenkins application."
     argument :name, "The name you wish to give your application", ["-a", "--app name"]
     argument :cartridge, "The first cartridge added to the application. Usually a web framework", ["-t", "--type cartridge"]
     argument :additional_cartridges, "A list of other cartridges such as databases you wish to add. Cartridges can also be added later using 'rhc cartridge add'", [], :arg_type => :list
     def create(name, cartridge, additional_cartridges)
+      options.default \
+        :dns => true,
+        :git => true
+
       warnings = []
       header "Creating application '#{name}'"
       table({"Namespace:" => options.namespace,
@@ -69,7 +75,7 @@ You may use this command to add the client to your application
 WARNING
       end
 
-      unless options.nodns
+      if options.dns
         unless dns_propagated? rest_app.host
           warnings << <<WARNING
 We were unable to lookup your hostname (#{rest_app.host}) in a reasonable amount of time.
@@ -84,7 +90,7 @@ WARNING
           return 0
         end
 
-        unless options.nogit
+        if options.git
           begin
             run_git_clone(rest_app)
           rescue RHC::GitException => e
@@ -302,7 +308,7 @@ WARNING
 
       def check_jenkins(app_name, rest_domain)
         debug "Checking if jenkins arguments are valid"
-        raise ArgumentError, "The --nodns option can't be used in conjunction with --enable-jenkins when creating an application.  Either remove the --nodns option or first install your application with --nodns and then use 'rhc cartridge add' to embed the Jenkins client." if options.nodns
+        raise ArgumentError, "The --no-dns option can't be used in conjunction with --enable-jenkins when creating an application.  Either remove the --no-dns option or first install your application with --no-dns and then use 'rhc cartridge add' to embed the Jenkins client." unless options.dns
 
 
         begin

--- a/lib/rhc/helpers.rb
+++ b/lib/rhc/helpers.rb
@@ -100,6 +100,26 @@ module RHC
     def debug(msg)
       puts "DEBUG: #{msg}" if debug?
     end
+
+    def deprecated_command(correct,short = false)
+      deprecated("This command is deprecated. Please use '#{correct}' instead.",short)
+    end
+
+    def deprecated_option(incorrect,correct)
+      deprecated("The option '#{incorrect}' is deprecated. Please use '#{correct}' instead")
+    end
+
+    def deprecated(msg,short = false)
+      info = " For porting and testing purposes you may switch this %s to a %s by setting the DISABLE_DEPRECATED environment variable to %d.  It is not recommended to do so in a production environment as this option may be removed in future releases."
+
+      msg << info unless short
+      if RHC::Helpers.disable_deprecated?
+        raise DeprecatedError.new(msg % ['error','warning',0])
+      else
+        warn "Warning: #{msg}\n" % ['warning','error',1]
+      end
+    end
+
     def say(msg)
       super
       msg


### PR DESCRIPTION
- Modified `--nogit` and `--nogit` options to be --no-git and --no-dns.
- Parse the values and print out a deprecation message if old values are used
  I believe this approach to finding deprecated args is much cleaner. It lets us explicitly tag them as deprecated and provide which value they replace. They will only replace the default value for the other option, so if that option provides a value, it will always be used.
  I wasn't sure if there was a way to hide the deprecated tags from the `--help` menu, so I added "DEPRECATED!" to the description. Removing them would be preferred.
- DRY up deprecation messaging
  I also moved the deprecation error messages to a helper to keep them consistent. It will also allow us to use them other places (for instance if we decide we want to deprecate config file options). It would be trivial to add another helper.
