### PR TITLE
Modified proxy parsing in rhc-common.rb

### DIFF
--- a/bin/rhc-chk
+++ b/bin/rhc-chk
@@ -129,17 +129,8 @@ end
 #
 # Check for proxy environment
 #
-if ENV['http_proxy']
-  if ENV['http_proxy']!~/^(\w+):\/\// then
-    ENV['http_proxy']="http://" + ENV['http_proxy']
-  end
-  proxy_uri=URI.parse(ENV['http_proxy'])
-  $http = Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password)
-  $debuginfo['environment']['proxy'] = "#{proxy_uri.user}:#{proxy_uri.password}@#{proxy_uri.host}:#{proxy_uri.port}"
-else
-  $http = Net::HTTP
-  $debuginfo['environment']['proxy'] = "none"
-end
+$http = RHC::Config.default_proxy
+$debuginfo['environment']['proxy'] = (RHC::Config.using_proxy? ? ENV['http_proxy'] : "none")
 
 #####################################
 #     Done setting up environment   #

--- a/lib/rhc-common.rb
+++ b/lib/rhc-common.rb
@@ -966,16 +966,8 @@ local_config_path = File.expand_path(@local_config_path)
 #
 # Check for proxy environment
 #
-if ENV['http_proxy']
-  if ENV['http_proxy']!~/^(\w+):\/\// then
-    ENV['http_proxy']="http://" + ENV['http_proxy']
-  end
-  proxy_uri=URI.parse(ENV['http_proxy'])
-  @http = Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password)
-else
-  @http = Net::HTTP
-end
 
+@http = RHC::Config.default_proxy
 
 def config_path
   return @opts_config_path ? @opts_config_path : @local_config_path


### PR DESCRIPTION
- Moved all calls that parsed the proxy ENV variable to a shared function
- Modified function to also check ENV['HTTP_PROXY']
- Added spec tests

NOTE: This pull request was originally opened against master, but it would be better to get it incorporated here
