### PR TITLE
Fix BZ829929. SSH key name to be a bit more decipherable than a stripped...

### DIFF
--- a/lib/rhc/wizard.rb
+++ b/lib/rhc/wizard.rb
@@ -182,7 +182,12 @@ public and private keys id_rsa keys.
         end
         hostname = Socket.gethostname.gsub(/\..*\z/,'')
         username = @username ? @username.gsub(/@.*/, '') : ''
-        pubkey_default_name = "clikey#{username}#{hostname}".gsub(/[^A-Za-z0-9]/,'')
+        pubkey_base_name = "#{username}#{hostname}".gsub(/[^A-Za-z0-9]/,'').slice(0,16)
+        pubkey_default_name = find_unique_key_name(
+          :keys => @ssh_keys,
+          :base => pubkey_base_name,
+          :max_length => RHC::DEFAULT_MAX_LENGTH
+        )
         
         paragraph do
           key_name =  ask("Provide a name for this key: ") do |q|
@@ -193,6 +198,22 @@ public and private keys id_rsa keys.
       end
 
       key_name
+    end
+    
+    # given the base name and the maximum length,
+    # find a name that does not clash with what is in opts[:keys]
+    def find_unique_key_name(opts)
+      keys = opts[:keys] || @ssh_keys
+      base = opts[:base] || 'default'
+      max  = opts[:max_length] || RHC::DEFAULT_MAX_LENGTH # in rhc-common.rb
+      key_name_suffix = 1
+      candidate = base
+      while @ssh_keys.detect { |k| k.name == candidate }
+        candidate = base.slice(0, max - key_name_suffix.to_s.length) +
+          key_name_suffix.to_s
+        key_name_suffix += 1
+      end
+      candidate
     end
 
     def upload_ssh_key

--- a/lib/rhc/wizard.rb
+++ b/lib/rhc/wizard.rb
@@ -4,6 +4,7 @@ require 'rhc/ssh_key_helpers'
 require 'highline/system_extensions'
 require 'net/ssh'
 require 'fileutils'
+require 'socket'
 
 module RHC
   class Wizard
@@ -179,7 +180,10 @@ public and private keys id_rsa keys.
           end
           return nil
         end
-        pubkey_default_name = key_fingerprint[0, 12].gsub(/[^0-9a-zA-Z]/,'')
+        hostname = Socket.gethostname.gsub(/\..*\z/,'')
+        username = @username ? @username.gsub(/@.*/, '') : ''
+        pubkey_default_name = "cli_key_#{username}_#{hostname}"
+        
         paragraph do
           key_name =  ask("Provide a name for this key: ") do |q|
             q.default = pubkey_default_name

--- a/lib/rhc/wizard.rb
+++ b/lib/rhc/wizard.rb
@@ -182,7 +182,7 @@ public and private keys id_rsa keys.
         end
         hostname = Socket.gethostname.gsub(/\..*\z/,'')
         username = @username ? @username.gsub(/@.*/, '') : ''
-        pubkey_default_name = "cli_key_#{username}_#{hostname}"
+        pubkey_default_name = "clikey#{username}#{hostname}".gsub(/[^A-Za-z0-9]/,'')
         
         paragraph do
           key_name =  ask("Provide a name for this key: ") do |q|

--- a/spec/rhc/wizard_spec.rb
+++ b/spec/rhc/wizard_spec.rb
@@ -621,6 +621,24 @@ describe RHC::Wizard do
       output = $terminal.read
       output.should match 'Updating'
     end
+    
+    it 'should pick a usable SSH key name' do
+      key_name = 'default'
+      wizard = FirstRunWizardDriver.new
+      key_data = wizard.get_mock_key_data
+      Socket.stub(:gethostname) { key_name }
+      $terminal.write_line("\n") # to accept default key name
+      wizard.ssh_keys = key_data
+      wizard.stub(:ssh_key_triple_for_default_key) { wizard.pub_key.chomp.split }
+      wizard.stub(:fingerprint_for_default_key) { "" } # this value is irrelevant
+      wizard.rest_client.stub(:add_key) { true }
+      
+      wizard.send(:upload_ssh_key)
+      output = $terminal.read
+      # since the clashing key name is short, we expect to present
+      # a key name with "1" attached to it.
+      output.should match "|" + key_name + "1" + "|"
+    end
   end
 
   module WizardDriver


### PR DESCRIPTION
... key fingerprint. Leaving the fingerprint code for now, to verify that the key is usable.
